### PR TITLE
Add support for Cataclysm Classic

### DIFF
--- a/HideButtonGlow_Cata.toc
+++ b/HideButtonGlow_Cata.toc
@@ -1,0 +1,17 @@
+## Interface: 40400
+## Version: v30
+## Author: dekallo
+## Title: Hide Button Glow
+## Notes: Prevents spells on your action bar from glowing
+## OptionalDeps: Ace3, LibButtonGlow-1.0, ElvUI, Dominos
+## SavedVariables: HideButtonGlowDB
+## IconTexture: Interface\AddOns\HideButtonGlow\icon
+## X-Website: https://www.curseforge.com/wow/addons/hide-button-glow
+## X-Curse-Project-ID: 426069
+## X-Wago-ID: RBKpVONE
+## X-WoWI-ID: 26179
+
+embeds.xml
+
+HideButtonGlow.lua
+options.lua

--- a/HideButtonGlow_Cata.toc
+++ b/HideButtonGlow_Cata.toc
@@ -1,5 +1,5 @@
 ## Interface: 40400
-## Version: v30
+## Version: @project-version@
 ## Author: dekallo
 ## Title: Hide Button Glow
 ## Notes: Prevents spells on your action bar from glowing


### PR DESCRIPTION
Add support for Cataclysm Classic - nothing else appears to need changing except adding a TOC. Whitelisting spells works as intended. Zero lua errors present.